### PR TITLE
Add disabled field support to pkgmux app definitions

### DIFF
--- a/apps/git-credential-manager.yaml
+++ b/apps/git-credential-manager.yaml
@@ -1,6 +1,6 @@
 name: git-credential-manager
 
-# cf. https://github.com/git-ecosystem/git-credential-manager
+# cf. https://github.com/git-ecosystem/git-credential-manager/blob/release/docs/install.md
 install:
   - type: brew
     cask: git-credential-manager

--- a/pkgmux/core/loader.sh
+++ b/pkgmux/core/loader.sh
@@ -15,6 +15,12 @@ load_app() {
     yq -o=json "$app_file"
 }
 
+# Check if an app is disabled
+is_disabled() {
+    local app_json="$1"
+    [[ $(echo "$app_json" | jq -r '.disabled // false') == "true" ]]
+}
+
 # List all available app names
 list_apps() {
     local apps_dir="$1"

--- a/pkgmux/pkgmux
+++ b/pkgmux/pkgmux
@@ -44,6 +44,11 @@ process_app() {
         return 1
     fi
 
+    if is_disabled "$app_json"; then
+        log_skip "$app_name (disabled)"
+        return 0
+    fi
+
     local install_entry
     install_entry=$(select_install_entry "$app_json")
 
@@ -131,7 +136,14 @@ cmd_uninstall() {
 }
 
 cmd_list() {
-    list_apps "$APPS_DIR"
+    local app_name app_json
+    while IFS= read -r app_name; do
+        if app_json=$(load_app "$app_name" "$APPS_DIR" 2>/dev/null) && is_disabled "$app_json"; then
+            echo "$app_name (disabled)"
+        else
+            echo "$app_name"
+        fi
+    done < <(list_apps "$APPS_DIR")
 }
 
 cmd_doctor() {
@@ -177,6 +189,26 @@ cmd_doctor() {
         local app_json
         if ! app_json=$(load_app "$app" "$APPS_DIR" 2>/dev/null); then
             $json_output || _doctor_log_error "$app: failed to load definition"
+            continue
+        fi
+
+        if is_disabled "$app_json"; then
+            if $json_output; then
+                json_results+=("$(jq -n --arg name "$app" '{
+                    name: $name,
+                    installed: false,
+                    version: null,
+                    latest_version: null,
+                    pinned_version: null,
+                    outdated: false,
+                    pinned_drift: false,
+                    missing_requires: [],
+                    disabled: true,
+                    skipped: true
+                }')")
+            else
+                $verbose && _doctor_log_skip "$app (disabled)" || true
+            fi
             continue
         fi
 


### PR DESCRIPTION
## Summary
- Add `is_disabled()` helper to `pkgmux/core/loader.sh` that checks the `disabled` YAML field
- Skip disabled apps in `process_app()` (covers install, upgrade, uninstall) with a log message
- Skip disabled apps in `cmd_doctor()` with JSON (`"disabled": true, "skipped": true`) and verbose text output
- Show `(disabled)` marker in `cmd_list()` output

## Test plan
- [x] Add `disabled: true` to a test app YAML and verify `pkgmux list` shows `(disabled)` marker
- [x] Run `pkgmux install <app>` — should skip with message
- [x] Run `pkgmux doctor -v <app>` — should show skip in verbose mode
- [x] Run `pkgmux doctor --json <app>` — should include `"disabled": true`
- [x] Remove `disabled: true` — all commands should work normally again

🤖 Generated with [Claude Code](https://claude.com/claude-code)