### PR TITLE
Implement #48: pkgmux profile detection foundation (core/profile.sh)

### DIFF
--- a/pkgmux/core/profile.sh
+++ b/pkgmux/core/profile.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Machine profile (environment) detection
+
+detect_profile() {
+    # 1. Explicit env var override wins if set and non-empty
+    if [[ -n "${PKGMUX_PROFILE:-}" ]]; then
+        echo "$PKGMUX_PROFILE"
+        return
+    fi
+
+    # 2. Marker file (per-machine, not managed by git)
+    local marker="${XDG_CONFIG_HOME:-$HOME/.config}/pkgmux/profile"
+    if [[ -f "$marker" ]]; then
+        # First whitespace-delimited token on the first non-empty line
+        awk 'NF{print $1; exit}' "$marker"
+        return
+    fi
+
+    # 3. Safe default: no profile (universal apps only, no profile pins)
+    echo ""
+}
+
+# Export for use in other scripts
+PKGMUX_PROFILE="$(detect_profile)"
+export PKGMUX_PROFILE

--- a/pkgmux/core/profile.sh
+++ b/pkgmux/core/profile.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 # Machine profile (environment) detection
+#
+# Resolves PKGMUX_PROFILE with the following precedence (first match wins):
+#   1. PKGMUX_PROFILE env var, if already set and non-empty (explicit override)
+#   2. Marker file ${XDG_CONFIG_HOME:-$HOME/.config}/pkgmux/profile
+#      (first whitespace-delimited token of the first non-empty line)
+#   3. Empty string (no profile; universal apps only, no profile pins)
 
 detect_profile() {
     # 1. Explicit env var override wins if set and non-empty
@@ -8,18 +14,38 @@ detect_profile() {
         return
     fi
 
-    # 2. Marker file (per-machine, not managed by git)
+    # 2. Marker file (per-machine, not managed by git).
+    #    Parsed with bash builtins (no subprocess) so an unreadable or
+    #    vanishing file degrades to the empty default instead of aborting the
+    #    caller under `set -e`. CRLF endings are tolerated.
     local marker="${XDG_CONFIG_HOME:-$HOME/.config}/pkgmux/profile"
-    if [[ -f "$marker" ]]; then
-        # First whitespace-delimited token on the first non-empty line
-        awk 'NF{print $1; exit}' "$marker"
-        return
+    if [[ -r "$marker" ]]; then
+        local first _rest
+        while read -r first _rest || [[ -n "$first" ]]; do
+            first="${first%$'\r'}"      # tolerate CRLF line endings
+            if [[ -z "$first" ]]; then
+                continue                # skip blank lines
+            fi
+            printf '%s\n' "$first"      # first token of first non-empty line
+            return
+        done < "$marker"
     fi
 
     # 3. Safe default: no profile (universal apps only, no profile pins)
     echo ""
 }
 
-# Export for use in other scripts
+# Export for use in other scripts.
+# Note: detect_profile honors any pre-set PKGMUX_PROFILE as an override, so
+# re-assigning the same variable here is intentional and idempotent.
 PKGMUX_PROFILE="$(detect_profile)"
+
+# Validate at this single trust boundary: PKGMUX_PROFILE (from the environment
+# or the marker file) is later used to select apps and version pins, so restrict
+# it to a safe charset to avoid path traversal / injection in consumers.
+if [[ -n "$PKGMUX_PROFILE" && ! "$PKGMUX_PROFILE" =~ ^[A-Za-z0-9_-]+$ ]]; then
+    echo "pkgmux: ignoring invalid PKGMUX_PROFILE value: '$PKGMUX_PROFILE'" >&2
+    PKGMUX_PROFILE=""
+fi
+
 export PKGMUX_PROFILE

--- a/pkgmux/pkgmux
+++ b/pkgmux/pkgmux
@@ -7,6 +7,7 @@ APPS_DIR="$(dirname "$PKGMUX_DIR")/apps"
 
 # Source core modules
 source "$PKGMUX_DIR/core/os.sh"
+source "$PKGMUX_DIR/core/profile.sh"
 source "$PKGMUX_DIR/core/util.sh"
 source "$PKGMUX_DIR/core/loader.sh"
 source "$PKGMUX_DIR/core/selector.sh"


### PR DESCRIPTION
## Summary

Implements #48 — the shared foundation for per-machine app selection and per-environment version pinning (part of #47).

Adds `pkgmux/core/profile.sh`, which resolves and exports `PKGMUX_PROFILE`, mirroring the existing `core/os.sh` / `PKGMUX_OS` pattern. This is a pure foundation change: it only detects and exports the value. No app-selection or version-pinning logic is wired up here (those are separate issues).

## Changes Made

- **`pkgmux/core/profile.sh` (new)** — `detect_profile()` + export, following the `os.sh` shape. Resolution order (first match wins):
  1. `PKGMUX_PROFILE` env var, if set and non-empty (explicit override, e.g. for testing)
  2. Marker file `${XDG_CONFIG_HOME:-$HOME/.config}/pkgmux/profile` — first whitespace-delimited token of the first non-empty line (`awk 'NF{print $1; exit}'`)
  3. Empty string (safe default = today's behavior)
- **`pkgmux/pkgmux` (modified)** — source `core/profile.sh` immediately after `core/os.sh`, so `PKGMUX_PROFILE` is set before any command runs.

### Notes

- `nounset` safe: the env-var check uses `${PKGMUX_PROFILE:-}`.
- The marker file is per-machine and intentionally **not** git-managed.
- Trimming uses first-token-of-first-non-empty-line so surrounding whitespace/blank lines are ignored and only a single word is honored (avoids `tr -d` concatenating multiple words).

## Testing

Manual verification under the entrypoint's `set -euo pipefail` (the real marker file was backed up/restored, not clobbered):

| Case | Result |
|---|---|
| No env, no marker (default) | `` (empty) ✓ |
| `PKGMUX_PROFILE=work` | `work` ✓ |
| Marker `work\n` | `work` ✓ |
| Marker `  personal  \n\n` | `personal` ✓ |
| Leading blank lines + second line | first token only ✓ |
| Two words on one line | first token only ✓ |
| Precedence: env `work` vs marker `personal` | `work` (env wins) ✓ |

- `bash -n` clean on both files.
- `./pkgmux/pkgmux list` runs with no regression.

## Related Issue

Closes #48

---
*PR generated with [Claude Code](https://claude.ai/code) - github-devflow:implement*