### PR TITLE
Add claude-notifications-go plugin and consolidate notification config

### DIFF
--- a/chezmoi/dot_claude/claude-notifications-go/config.json
+++ b/chezmoi/dot_claude/claude-notifications-go/config.json
@@ -1,0 +1,8 @@
+{
+  "notifications": {
+    "desktop": {
+      "sound": false
+    },
+    "notifyOnlyWhenUnfocused": true
+  }
+}

--- a/chezmoi/dot_claude/settings.json.tmpl
+++ b/chezmoi/dot_claude/settings.json.tmpl
@@ -1,29 +1,5 @@
 {
   "hooks": {
-{{ if eq .chezmoi.os "linux" }}
-    "Notification": [
-      {
-        "matcher": "",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "notify-send -a 'Claude Code' -i dialog-question -u normal \"$(basename \"$PWD\")\" 'Waiting for your input'"
-          }
-        ]
-      }
-    ],
-    "Stop": [
-      {
-        "matcher": "",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "notify-send -a 'Claude Code' -i emblem-default -u normal \"$(basename \"$PWD\")\" 'Finished my work'"
-          }
-        ]
-      }
-    ],
-{{ end }}
     "PostToolUse": [
       {
         "matcher": "Write|Edit|NotebookEdit",
@@ -40,6 +16,17 @@
     "code-review@claude-plugins-official": true,
     "commit-commands@claude-plugins-official": true,
     "gopls-lsp@claude-plugins-official": true,
-    "plugin-dev@claude-plugins-official": true
-  }
+    "plugin-dev@claude-plugins-official": true,
+    "claude-notifications-go@claude-notifications-go": true
+  },
+  "extraKnownMarketplaces": {
+    "claude-notifications-go": {
+      "source": {
+        "source": "github",
+        "repo": "777genius/claude-notifications-go"
+      }
+    }
+  },
+  "skipWorkflowUsageWarning": true,
+  "theme": "light-daltonized"
 }


### PR DESCRIPTION
## 概要
デスクトップ通知プラグイン [claude-notifications-go](https://github.com/777genius/claude-notifications-go) を導入し、Claude Code の通知設定を整理する。

## 変更内容
- **プラグイン有効化**: `settings.json.tmpl` の `enabledPlugins` に `claude-notifications-go` を追加し、`extraKnownMarketplaces` にマーケットプレイスを宣言（新規マシンでの再現性のため）
- **通知設定を chezmoi 管理化**: `chezmoi/dot_claude/claude-notifications-go/config.json` を新規作成
  - デスクトップ通知のみ（Webhook なし）
  - 消音（`desktop.sound: false`）
  - 未フォーカス時のみ通知（`notifyOnlyWhenUnfocused: true`）
  - 部分設定はプラグインのデフォルトにマージされる実装のため最小構成
- **既存設定の整理**: `theme` (light-daltonized) と `skipWorkflowUsageWarning` をテンプレートに固定。`model` は各マシンのローカルに委ねる（テンプレートには含めない）
- **重複フックの削除**: Linux 用の `notify-send` による `Notification`/`Stop` フックを削除。クロスプラットフォーム対応の本プラグインが役割を引き継ぐため（Linux での二重通知を回避）

## 補足
- 本プラグインは Claude Code のプラグインシステムで管理されるため、pkgmux の app 定義（`apps/*.yaml`）は作成していない（既存の他プラグインと同じ扱い）
- macOS で動作確認済み（通知発火・消音・ブランチ/リポジトリ名サブタイトル・クリックでフォーカスを確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)