### PR TITLE
Implement #50: Add mise handler for exact version pinning

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,6 +78,7 @@ pkgmux is a unified package management tool that works across macOS (Homebrew) a
 - `brew` - Homebrew formulas and casks (macOS)
 - `apt` - apt packages (Linux)
 - `go` - go install (requires: go)
+- `mise` - tools via [mise](https://mise.jdx.dev/) with exact version pinning, same on macOS/Linux (requires: mise)
 - `custom` - Custom install scripts
 
 **App Definition Schema:**
@@ -126,10 +127,17 @@ install:
   - type: go
     package: example.com/cmd/example  # @latest is appended automatically if no @version suffix
 
+  - type: mise
+    tool: terraform            # mise tool name or backend spec (aqua:..., ubi:..., pipx:...)
+    pinned_version: "1.9.5"    # optional: pin to exact version; omit to track latest
+    # Pin precedence: this field > PKGMUX_PINNED_VERSION env var > latest.
+    # `mise use -g` writes ~/.config/mise/config.toml (outside chezmoi); the
+    # active version is the source of truth, observable via `mise current`.
+
   - type: custom
     os: linux
     check: command -v example
-    pinned_version: "1.0.0"    # optional: pin to specific version (custom only, omit for latest)
+    pinned_version: "1.0.0"    # optional: pin to specific version (custom/mise, omit for latest)
     script: |
       # Use PKGMUX_PINNED_VERSION env var to install a specific version when pinned
       VERSION="${PKGMUX_PINNED_VERSION:-$(curl -s "https://api.example.com/latest" | jq -r '.tag_name')}"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,7 +128,10 @@ install:
     package: example.com/cmd/example  # @latest is appended automatically if no @version suffix
 
   - type: mise
-    tool: terraform            # mise tool name or backend spec (aqua:..., ubi:..., pipx:...)
+    tool: terraform            # a registered mise tool (e.g. terraform, node), OR a
+                               # backend spec to install from a specific source, e.g.
+                               # aqua:owner/repo, ubi:owner/repo, pipx:pkg, npm:pkg.
+                               # See https://mise.jdx.dev/registry.html and the backend docs.
     pinned_version: "1.9.5"    # optional: pin to exact version; omit to track latest
     # Pin precedence: this field > PKGMUX_PINNED_VERSION env var > latest.
     # `mise use -g` writes ~/.config/mise/config.toml (outside chezmoi); the

--- a/apps/terraform.yaml
+++ b/apps/terraform.yaml
@@ -1,7 +1,11 @@
 name: terraform
 
-# cf. https://developer.hashicorp.com/terraform/install
+# Managed via mise for exact version pinning (works the same on macOS/Linux).
+# cf. https://mise.jdx.dev/  |  https://developer.hashicorp.com/terraform/install
+requires:
+  - mise
+
 install:
-  - type: brew
-    package: hashicorp/tap/terraform
-    os: macos
+  - type: mise
+    tool: terraform
+    # pinned_version: "1.9.5"   # optional; omit to track latest

--- a/pkgmux/handlers/mise.sh
+++ b/pkgmux/handlers/mise.sh
@@ -1,0 +1,228 @@
+#!/usr/bin/env bash
+# mise handler - exact version pinning via mise (https://mise.jdx.dev/)
+
+# Get the tool name / backend spec (aqua:..., ubi:..., pipx:...) from the entry
+_mise_get_tool() {
+    local install_entry="$1"
+    echo "$install_entry" | jq -r '.tool // empty'
+}
+
+# Resolve the pinned version, if any.
+# Precedence: install-entry `pinned_version` field > PKGMUX_PINNED_VERSION env
+# var (the hook the future profile pin-layer drives) > none (track latest).
+_mise_get_pinned_version() {
+    local install_entry="$1"
+    local pinned
+    pinned=$(echo "$install_entry" | jq -r '.pinned_version // empty')
+    if [[ -z "$pinned" ]]; then
+        pinned="${PKGMUX_PINNED_VERSION:-}"
+    fi
+    echo "$pinned"
+}
+
+# Resolve the mise ref to install/use: <tool>@<pin> when pinned, else <tool>@latest
+_mise_resolve_ref() {
+    local install_entry="$1"
+    local tool pinned
+    tool=$(_mise_get_tool "$install_entry")
+    pinned=$(_mise_get_pinned_version "$install_entry")
+    if [[ -n "$pinned" ]]; then
+        echo "${tool}@${pinned}"
+    else
+        echo "${tool}@latest"
+    fi
+}
+
+_mise_is_installed() {
+    local tool="$1"
+    # `mise current <tool>` prints the active version to stdout (empty when the
+    # tool has no global version set); the "no version set" warning goes to stderr.
+    [[ -n "$(mise current "$tool" 2>/dev/null)" ]]
+}
+
+handler_mise_status() {
+    local app_name="$1"
+    local install_entry="$2"
+    local app_json="$3"
+
+    local tool
+    tool=$(_mise_get_tool "$install_entry")
+
+    if _mise_is_installed "$tool"; then
+        local version
+        version=$(handler_mise_current_version "$app_name" "$install_entry" "$app_json")
+        log_ok "$app_name: installed ($version)"
+        return 0
+    else
+        log_error "$app_name: not installed"
+        return 1
+    fi
+}
+
+handler_mise_install() {
+    local app_name="$1"
+    local install_entry="$2"
+    local app_json="$3"
+
+    local tool
+    tool=$(_mise_get_tool "$install_entry")
+
+    if [[ -z "$tool" ]]; then
+        log_error "$app_name: no tool specified for mise handler"
+        return 1
+    fi
+
+    if _mise_is_installed "$tool"; then
+        log_ok "$app_name: already installed"
+        return 0
+    fi
+
+    local ref
+    ref=$(_mise_resolve_ref "$install_entry")
+
+    log_info "$app_name: installing via mise ($ref)..."
+    if mise use -g "$ref"; then
+        log_ok "$app_name: installed"
+    else
+        log_error "$app_name: installation failed"
+        return 1
+    fi
+}
+
+handler_mise_upgrade() {
+    local app_name="$1"
+    local install_entry="$2"
+    local app_json="$3"
+
+    local tool
+    tool=$(_mise_get_tool "$install_entry")
+
+    if ! _mise_is_installed "$tool"; then
+        log_warn "$app_name: not installed, installing..."
+        handler_mise_install "$app_name" "$install_entry" "$app_json"
+        return $?
+    fi
+
+    local current_version
+    current_version=$(handler_mise_current_version "$app_name" "$install_entry" "$app_json" 2>/dev/null) || true
+
+    # Pinning guard: hold at the pinned version, advancing only if drifted
+    local pinned_version
+    pinned_version=$(_mise_get_pinned_version "$install_entry")
+    if [[ -n "$pinned_version" ]]; then
+        if [[ -n "$current_version" && "$current_version" != "installed, version unknown" && "$current_version" == "$pinned_version" ]]; then
+            log_ok "$app_name: already at pinned version ($pinned_version)"
+            return 0
+        fi
+        log_info "$app_name: pinned to $pinned_version, updating..."
+        if mise use -g "${tool}@${pinned_version}"; then
+            log_ok "$app_name: set to pinned version ($pinned_version)"
+        else
+            log_error "$app_name: upgrade failed"
+            return 1
+        fi
+        return 0
+    fi
+
+    # Unpinned: advance to latest when behind
+    local latest_version
+    latest_version=$(handler_mise_latest_version "$app_name" "$install_entry" "$app_json" 2>/dev/null) || true
+    if [[ -n "$current_version" && "$current_version" != "installed, version unknown" && -n "$latest_version" && "$current_version" == "$latest_version" ]]; then
+        log_ok "$app_name: already up to date ($current_version)"
+        return 0
+    fi
+
+    log_info "$app_name: upgrading via mise..."
+    if mise use -g "${tool}@latest"; then
+        log_ok "$app_name: upgraded"
+    else
+        log_error "$app_name: upgrade failed"
+        return 1
+    fi
+}
+
+handler_mise_uninstall() {
+    local app_name="$1"
+    local install_entry="$2"
+    local app_json="$3"
+
+    local tool
+    tool=$(_mise_get_tool "$install_entry")
+
+    if ! _mise_is_installed "$tool"; then
+        log_skip "$app_name: not installed"
+        return 0
+    fi
+
+    log_info "$app_name: removing via mise..."
+    # Drop it from the global config, then remove every installed version
+    # (--all avoids the "multiple versions" ambiguity when more than one exists).
+    if mise use -g --rm "$tool" && mise uninstall --all "$tool"; then
+        log_ok "$app_name: uninstalled"
+    else
+        log_error "$app_name: uninstall failed"
+        return 1
+    fi
+}
+
+handler_mise_latest_version() {
+    local app_name="$1"
+    local install_entry="$2"
+    local app_json="$3"
+
+    local tool
+    tool=$(_mise_get_tool "$install_entry")
+
+    # `mise latest <tool>` prints the bare newest version (empty on failure,
+    # which doctor treats as "cannot check", same as go/custom).
+    mise latest "$tool" 2>/dev/null || true
+}
+
+handler_mise_outdated() {
+    local app_name="$1"
+    local install_entry="$2"
+    local app_json="$3"
+
+    local tool
+    tool=$(_mise_get_tool "$install_entry")
+
+    if ! _mise_is_installed "$tool"; then
+        log_skip "$app_name: not installed"
+        return 0
+    fi
+
+    local current_version
+    current_version=$(handler_mise_current_version "$app_name" "$install_entry" "$app_json")
+
+    if [[ -z "$current_version" || "$current_version" == "installed, version unknown" ]]; then
+        log_warn "$app_name: cannot check (no version info)"
+        return 0
+    fi
+
+    local latest_version
+    latest_version=$(handler_mise_latest_version "$app_name" "$install_entry" "$app_json")
+
+    if [[ -z "$latest_version" ]]; then
+        log_warn "$app_name: cannot check (failed to query latest version)"
+        return 0
+    fi
+
+    if [[ "$current_version" != "$latest_version" ]]; then
+        log_warn "$app_name: update available (installed: $current_version, latest: $latest_version)"
+    else
+        log_ok "$app_name: up to date ($current_version)"
+    fi
+}
+
+handler_mise_current_version() {
+    local app_name="$1"
+    local install_entry="$2"
+    local app_json="$3"
+
+    local tool
+    tool=$(_mise_get_tool "$install_entry")
+
+    local ver
+    ver=$(mise current "$tool" 2>/dev/null)
+    echo "${ver:-installed, version unknown}"
+}

--- a/pkgmux/pkgmux
+++ b/pkgmux/pkgmux
@@ -326,6 +326,12 @@ cmd_doctor() {
             local latest_cmd
             latest_cmd=$(_custom_get_latest_cmd "$install_entry")
             [[ -z "$latest_cmd" ]] && can_check_outdated=false
+        elif [[ "$handler_type" == "mise" ]]; then
+            # A pinned mise tool is deliberately held at its version; report it as
+            # drift (below) rather than nagging "outdated" toward latest.
+            local mise_pin
+            mise_pin=$(echo "$install_entry" | jq -r '.pinned_version // empty')
+            [[ -n "$mise_pin" ]] && can_check_outdated=false
         fi
 
         if $can_check_outdated && [[ -n "$current_version" && "$current_version" != "installed, version unknown" ]]; then
@@ -340,11 +346,11 @@ cmd_doctor() {
             fi
         fi
 
-        # Check pinned version drift (custom handler with pinned_version)
+        # Check pinned version drift (custom/mise handlers with pinned_version)
         local drift_msg=""
         local has_pinned_drift=false
         local pinned_version=""
-        if [[ "$handler_type" == "custom" ]]; then
+        if [[ "$handler_type" == "custom" || "$handler_type" == "mise" ]]; then
             pinned_version=$(echo "$install_entry" | jq -r '.pinned_version // empty')
             if [[ -n "$pinned_version" && -n "$current_version" && "$current_version" != "installed, version unknown" && "$current_version" != "$pinned_version" ]]; then
                 drift_msg="pinned version drift (pinned: $pinned_version)"


### PR DESCRIPTION
## Summary

Implements #50

Adds a `mise` handler so tools can be pinned to an exact version on macOS and Linux without fighting Homebrew — the engine for Tier 1 tools under the profile pin-layer (#47 family). Follows the existing `go`/`custom` handler patterns and is auto-discovered by the `handler_${type}_${action}` dispatch (no dispatcher changes).

## Changes Made

- **`pkgmux/handlers/mise.sh`** (new) — full `handler_mise_<action>` contract: `install`, `upgrade`, `uninstall`, `status`, `current_version`, `latest_version`, `outdated`.
  - Installs via `mise use -g <tool>@<version>`.
  - Pin precedence: install-entry `pinned_version:` field → `PKGMUX_PINNED_VERSION` env var (the future profile pin-layer hook) → `@latest`.
  - `uninstall` drops the tool from global config (`mise use -g --rm`) then removes all installed versions (`mise uninstall --all`, avoiding the multi-version ambiguity).
- **`pkgmux/pkgmux`** — doctor now reports `pinned_drift` for `mise` entries (previously custom-only), and suppresses the `outdated` flag for a pinned mise tool so it surfaces as drift rather than nagging toward latest.
- **`apps/terraform.yaml`** — migrated brew → mise (`requires: [mise]`) as the end-to-end proof.
- **`CLAUDE.md`** — documented the `mise` handler (schema, pin precedence, `~/.config/mise/config.toml` note).

Deferred (follow-up): migrating `apps/nodejs.yaml` from nvm — it changes a working setup; terraform alone meets the "1–2 tools" acceptance bar.

## Testing

Manual end-to-end against mise 2026.6.14 (this repo has no unit-test harness):

- **Exact pin:** `PKGMUX_PINNED_VERSION=1.9.5 install terraform` → `mise current terraform` == `1.9.5`.
- **Doctor (unpinned entry):** `installed:true, version:1.9.5, latest:1.15.8, outdated:true`.
- **Doctor (pinned == installed):** `pinned_drift:false`, `outdated` suppressed.
- **Doctor (pinned 1.15.8 ≠ installed 1.9.5):** `pinned_drift:true`.
- **Upgrade** (pinned, already at pin) → no-op; **uninstall** → fully clean (config + all versions removed; re-run reports "not installed").
- **Dispatch discovery** and all pure helpers (tool/pin/ref resolution) verified.
- **Regression:** `custom` (nodejs) and `go` (delve) doctor paths unaffected.

> Note: `terraform` was previously brew-managed; brew's copy stays on `PATH` until a manual `brew uninstall terraform`. The mise handler tracks state via `mise current`, so it is self-consistent — the brew cleanup is an optional post-merge step.

## Related Issue

Closes #50

---
*PR generated with [Claude Code](https://claude.com/claude-code) - github-devflow:implement*