### PR TITLE
Auto-rename tmux window to "<repo>: <claude session name>"

### DIFF
--- a/chezmoi/dot_claude/settings.json.tmpl
+++ b/chezmoi/dot_claude/settings.json.tmpl
@@ -10,6 +10,26 @@
           }
         ]
       }
+    ],
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "zsh -c 'source ~/.config/zsh/tmux.zsh && sync-tmux-window-name'"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "zsh -c 'source ~/.config/zsh/tmux.zsh && sync-tmux-window-name'"
+          }
+        ]
+      }
     ]
   },
   "enabledPlugins": {

--- a/chezmoi/dot_config/zsh/tmux.zsh
+++ b/chezmoi/dot_config/zsh/tmux.zsh
@@ -111,6 +111,54 @@ ide() {
     tmux select-pane -t "$hx_pane"
 }
 
+# Rename the tmux window running a Claude Code session to
+# "<repo>: <claude-session-name>" so the window/status bar reflects which
+# conversation is running. Intended to run as a Claude Code hook (Stop /
+# SessionStart), which passes session_id/cwd as a JSON payload on stdin.
+#
+# The session's live title (auto-slug, or whatever /rename set) and its
+# exact tmux target live in ~/.claude/sessions/<pid>.json — NOT in
+# sessions-index.json, which on this machine is only rewritten sporadically
+# and has no entry at all for a session that's still running. Matching by
+# tmux target (rather than trusting $TMUX in the hook's own environment)
+# also means this works correctly even if the hook subprocess's env differs
+# from the pane that's actually running Claude.
+sync-tmux-window-name() {
+    command -v tmux >/dev/null 2>&1 || return 0
+
+    local input session_id
+    input=$(cat)
+    session_id=$(echo "$input" | jq -r '.session_id // empty')
+    [[ -z "$session_id" ]] && return 0
+
+    local session_file f
+    for f in $(find ~/.claude/sessions -maxdepth 1 -name '*.json' 2>/dev/null); do
+        [[ "$(jq -r '.sessionId // empty' "$f" 2>/dev/null)" == "$session_id" ]] && { session_file="$f"; break }
+    done
+    [[ -z "$session_file" ]] && return 0
+
+    local session_name tmux_target
+    session_name=$(jq -r '.name // empty' "$session_file" 2>/dev/null)
+    tmux_target=$(jq -r '.tmux // empty' "$session_file" 2>/dev/null)
+    [[ -z "$session_name" || -z "$tmux_target" ]] && return 0
+
+    local cwd
+    cwd=$(echo "$input" | jq -r '.cwd // empty')
+    [[ -z "$cwd" ]] && cwd=$(jq -r '.cwd // empty' "$session_file")
+
+    local repo_name
+    repo_name=$(basename "$(git -C "$cwd" rev-parse --show-toplevel 2>/dev/null || echo "$cwd")")
+
+    local max_len=40
+    if (( ${#session_name} > max_len )); then
+        session_name="${session_name[1,$max_len]}…"
+    fi
+
+    # tmux_target is "session:window.pane" — window rename needs "session:window"
+    local window_target="${tmux_target%.*}"
+    tmux rename-window -t "$window_target" "${repo_name}: ${session_name}"
+}
+
 # Reload all buffers in a Helix pane within the current tmux window.
 # Silently does nothing if not in tmux or no HELIX_PANE is found.
 hx-reload() {


### PR DESCRIPTION
## Summary
- Adds `sync-tmux-window-name` to `chezmoi/dot_config/zsh/tmux.zsh`, which renames the tmux window running a Claude Code session to `"<repo>: <session name>"`.
- Wires it in as a `SessionStart`/`Stop` hook in `chezmoi/dot_claude/settings.json.tmpl` so it fires when a session starts/resumes and after each turn.
- Reads the live session title and exact tmux target from `~/.claude/sessions/<pid>.json` (the file Claude Code actively maintains per running process) rather than `sessions-index.json`, which is only rewritten sporadically and has no entry for a session that's still in progress.

## Test plan
- [x] Manually invoked the hook via `zsh -c 'source ~/.config/zsh/tmux.zsh && sync-tmux-window-name'` with a real session's JSON payload on stdin and confirmed the tmux window renamed correctly.
- [x] Deployed via `chezmoi apply` and confirmed `~/.config/zsh/tmux.zsh` matches source.
- [x] Confirmed the window keeps the manually/auto-assigned name (tmux disables `automatic-rename` once a window is renamed via `rename-window`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)