### PR TITLE
Add tmux keybinding to sort windows alphabetically by name

### DIFF
--- a/chezmoi/dot_config/tmux/tmux.conf
+++ b/chezmoi/dot_config/tmux/tmux.conf
@@ -124,6 +124,18 @@ bind % split-window -h -c "#{pane_current_path}"
 # IDE layout (Helix + Claude Code)
 bind C-d run-shell 'zsh -c "source ~/.config/zsh/tmux.zsh && ide"'
 
+# Sort windows alphabetically by name
+bind S run-shell '\
+  session=$(tmux display-message -p "#S") ; \
+  i=1 ; \
+  tmux list-windows -t "$session" -F "#{window_index} #{window_name}" | sort -k2 | \
+  while read -r idx name; do \
+    tmux move-window -s "$session:$idx" -t "$session:900$i" ; \
+    i=$((i+1)) ; \
+  done ; \
+  tmux move-window -r -t "$session" \
+'
+
 # Popup toggles (per-window)
 bind C-g popup -xC -yC -w80% -h80% -E -d "#{pane_current_path}" '\
   if echo "$(tmux display -p -F "#{session_name}")" | grep -q "^lazygit-" ; then \


### PR DESCRIPTION
Binds prefix+S to stage windows into a high-index range in
name-sorted order, then renumber (move-window -r) back down to
base-index, since tmux has no native window-sort command.