### PR TITLE
Fix tmux window sort binding being a silent no-op

### DIFF
--- a/chezmoi/dot_config/tmux/tmux.conf
+++ b/chezmoi/dot_config/tmux/tmux.conf
@@ -125,15 +125,22 @@ bind % split-window -h -c "#{pane_current_path}"
 bind C-d run-shell 'zsh -c "source ~/.config/zsh/tmux.zsh && ide"'
 
 # Sort windows alphabetically by name
+# NOTE: run-shell expands #... formats before the shell sees the string, so #S and
+#       #{window_id} are substituted here by tmux (no subshell needed). The format
+#       passed to list-windows must be escaped as ##{...} so the shell receives a
+#       literal #{...} for tmux to expand per window; without the escape it collapses
+#       to the current window's values and the sort silently does nothing.
 bind C-s run-shell '\
-  session=$(tmux display-message -p "#S") ; \
+  session="#S" ; \
+  active="#{window_id}" ; \
   i=1 ; \
-  tmux list-windows -t "$session" -F "#{window_index} #{window_name}" | sort -k2 | \
+  tmux list-windows -t "$session" -F "##{window_index} ##{window_name}" | sort -k2 | \
   while read -r idx name; do \
-    tmux move-window -s "$session:$idx" -t "$session:900$i" ; \
+    tmux move-window -d -s "$session:$idx" -t "$session:900$i" ; \
     i=$((i+1)) ; \
   done ; \
-  tmux move-window -r -t "$session" \
+  tmux move-window -r -t "$session" ; \
+  tmux select-window -t "$active" \
 '
 
 # Popup toggles (per-window)


### PR DESCRIPTION
## Problem

`prefix + C-s` (sort windows alphabetically, added in #62) did nothing.

`run-shell` expands `#...` formats *before* the shell sees the command string, so:

```
tmux list-windows -t "$session" -F "#{window_index} #{window_name}"
```

had the format substituted up front with the **current window's** values. The shell actually ran `list-windows -F "3 mmm"`, which printed that one constant line once per window. The loop then tried to move index 3 over and over, failing with `can't find window: 3` — into a run-shell output pane that is never surfaced, so the key looked like a no-op.

## Fix

- Escape the format as `##{window_index} ##{window_name}` so the shell receives a literal `#{...}` for tmux to expand per window.
- Since formats are expanded anyway, drop the two `display-message` subshells in favor of `session="#S"` and `active="#{window_id}"`.
- Preserve the active window across the sort: `move-window -d` avoids switching to each relocated window, and a trailing `select-window` restores the original by window id (ids survive the `-r` renumber).
- Add a comment recording the `##{...}` escaping requirement, since the failure mode is invisible.

## Verification

Reproduced the old behavior by running the exact post-expansion text — `can't find window: 3`, window order unchanged.

Fixed version, exercised through tmux's real `run-shell` expansion path on a live session (active window `mmm`, one name containing a space):

```
before:  1 zzz | 2 aaa | 3 mmm <== ACTIVE | 4 repo: bbb
after:   1 aaa | 2 mmm <== ACTIVE | 3 repo: bbb | 4 zzz
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)