### PR TITLE
Treat Option as Alt on macOS in Ghostty and kitty

### DIFF
--- a/chezmoi/dot_config/ghostty/config.tmpl
+++ b/chezmoi/dot_config/ghostty/config.tmpl
@@ -6,6 +6,13 @@ scrollback-limit = 20000
 
 # Key mappings
 keybind = shift+enter=text:\n
+{{ if eq .chezmoi.os "darwin" }}
+# Send Alt (ESC prefix) for Option+key instead of composing Unicode characters.
+# Ghostty only defaults this to true for U.S. Standard / U.S. International
+# layouts; with a Japanese input source it would default to false and swallow
+# tmux bindings such as "prefix M-1" (select-layout even-horizontal).
+macos-option-as-alt = true
+{{ end }}
 
 # Notifications
 desktop-notifications = true

--- a/chezmoi/dot_config/kitty/kitty.conf.tmpl
+++ b/chezmoi/dot_config/kitty/kitty.conf.tmpl
@@ -6,6 +6,11 @@ scrollback_lines 20000
 
 # Key mappings
 map shift+enter send_text all \n
+{{ if eq .chezmoi.os "darwin" }}
+# Send Alt (ESC prefix) for Option+key instead of composing Unicode characters,
+# so tmux bindings such as "prefix M-1" (select-layout even-horizontal) arrive.
+macos_option_as_alt yes
+{{ end }}
 
 # Font
 font_family HackGen Console NF


### PR DESCRIPTION
## Problem

tmux's default `prefix M-1` … `M-7` layout bindings (`select-layout even-horizontal` and friends) were silently dead on macOS.

The bindings themselves were fine — `tmux list-keys -T prefix` shows all seven present and correctly bound. The terminal was never delivering the Alt modifier in the first place.

## Root cause

Ghostty only defaults `macos-option-as-alt` to `true` for **U.S. Standard** and **U.S. International** keyboard layouts. With a Japanese input source active (`com.google.inputmethod.Japanese`), it resolves to `false`, so Option+1 composes the printable character `¡` and tmux never sees `M-1`.

kitty's `macos_option_as_alt` defaults to `no` and has the same effect, so it carried the identical latent bug.

## Change

Set both explicitly inside the existing `{{ if eq .chezmoi.os "darwin" }}` template block:

- `chezmoi/dot_config/ghostty/config.tmpl` → `macos-option-as-alt = true`
- `chezmoi/dot_config/kitty/kitty.conf.tmpl` → `macos_option_as_alt yes`

## Trade-off

This disables Option-based Unicode composition (`⌥1` → `¡`, `⌥5` → `∞`) **in the terminal only**. Since the IME switches via 英数/かな rather than Option, nothing is lost in practice. Both settings also accept `left` or `right` if one Option key should keep composing.

## Verification

- `chezmoi diff` confirms both templates render correctly under darwin
- `chezmoi apply` applied; settings present in `~/.config/ghostty/config` and `~/.config/kitty/kitty.conf`
- No change to the `bind -n C-b` IME hook or the `switch-client -T prefix` hand-off — those were not involved

🤖 Generated with [Claude Code](https://claude.com/claude-code)